### PR TITLE
feat: add stringRequest method

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,20 @@ Make a `query` request with a `client` including the optional `variables` object
 
 Make a `query` request with a `client` including the optional `variables` object, returning just the `data` field.
 
+### `data = await client.stringRequest(body)`
+
+Make a request with a `body` string to the configured GQL endpoint.  The body should be in the form of:
+
+
+```js
+const body = JSON.stringify({
+  query: '{ viewer { id } }',
+  variables: {}
+})
+```
+
+Useful with tools like [SWR](https://github.com/vercel/swr), where you usually stringify a query and variables object into a cache key that gets passed to your fetcher function.  With `stringRequest`, you can avoid double `JSON.stringify` problems, or complex variable scope passing.
+
 ### `client = client.setHeaders(headers)`
 
 Pass a `headers` object to a client to customize the headers.
@@ -111,6 +125,10 @@ Convenience function to instantiate a client and make a request in a single func
 ### `data = request(url, query, [variables])`
 
 Convenience function to instantiate a client and make a request in a single function call.
+
+### `data = stringRequest(url, body)`
+
+Convenience function to instantiate a client and make a `stringRequest` in a single function call.
 
 ## Examples
 

--- a/cjs/index.test.js
+++ b/cjs/index.test.js
@@ -4,7 +4,7 @@ const body = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* ista
 const express = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('express'))
 const { createServer } = require('http')
 
-const { GraphQLClient, request, rawRequest } = require('./index.js')
+const { GraphQLClient, request, rawRequest, stringRequest } = require('./index.js')
 
 tap.afterEach((done, t) => {
   // https://stackoverflow.com/questions/10378690/remove-route-mappings-in-nodejs-express/28369539#28369539
@@ -83,6 +83,30 @@ tap.test('minimal raw query', async t => {
     }
   }).body
   const { headers, ...result } = await rawRequest(ctx.url, '{ viewer { id } }')
+
+  t.deepEqual(result, { data, extensions, status: 200 })
+})
+
+tap.test('minimal string query', async t => {
+  const { extensions, data } = ctx.mock({
+    body: {
+      data: {
+        viewer: {
+          id: 'some-id'
+        }
+      },
+      extensions: {
+        version: '1'
+      }
+    }
+  }).body
+
+  const body = JSON.stringify({
+    query: '{ viewer { id } }',
+    variables: {}
+  })
+
+  const { headers, ...result } = await stringRequest(ctx.url, body)
 
   t.deepEqual(result, { data, extensions, status: 200 })
 })

--- a/esm/index.test.js
+++ b/esm/index.test.js
@@ -3,7 +3,7 @@ import body from 'body-parser'
 import express from 'express'
 import { createServer } from 'http'
 
-import { GraphQLClient, request, rawRequest } from './index.js'
+import { GraphQLClient, request, rawRequest, stringRequest } from './index.js'
 
 tap.afterEach((done, t) => {
   // https://stackoverflow.com/questions/10378690/remove-route-mappings-in-nodejs-express/28369539#28369539
@@ -82,6 +82,30 @@ tap.test('minimal raw query', async t => {
     }
   }).body
   const { headers, ...result } = await rawRequest(ctx.url, '{ viewer { id } }')
+
+  t.deepEqual(result, { data, extensions, status: 200 })
+})
+
+tap.test('minimal string query', async t => {
+  const { extensions, data } = ctx.mock({
+    body: {
+      data: {
+        viewer: {
+          id: 'some-id'
+        }
+      },
+      extensions: {
+        version: '1'
+      }
+    }
+  }).body
+
+  const body = JSON.stringify({
+    query: '{ viewer { id } }',
+    variables: {}
+  })
+
+  const { headers, ...result } = await stringRequest(ctx.url, body)
 
   t.deepEqual(result, { data, extensions, status: 200 })
 })


### PR DESCRIPTION
stringRequest lets you utilize the class options, error handling and other benefits to using gqlr, but you are in charge of creating the string body sent to the graphql endpoint.  This is helpful when working with libraries like SWR, where you need to stringify js objects into a cache key, that is then passed to your fetcher function.